### PR TITLE
Test project - render halting option

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -307,6 +307,8 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DebugAmbientOcclusion);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::Antialiasing);
 
+    addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::NoRender);
+
     MenuWrapper* ambientLightMenu = renderOptionsMenu->addMenu(MenuOption::RenderAmbientLight);
     QActionGroup* ambientLightGroup = new QActionGroup(ambientLightMenu);
     ambientLightGroup->setExclusive(true);


### PR DESCRIPTION
This is a pull request from applicant Mikhail Kabakov.
Here I implemented one of the test projects - added a menu option that allows to halt the openGL rendering of the 3D scene.

The 3 affected files are:
hifi\interface\src\Menu.h:
const QString NoRender = "Halt rendering of the world";

hifi\interface\src\Menu.cpp
addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::NoRender);

hifi\interface\src\Application.cpp
// Don't render anything if this is checked
if (Menu::getInstance()->isOptionChecked(MenuOption::NoRender)){
        return;
}
